### PR TITLE
[Transactional Emails] Send Contact Form emails

### DIFF
--- a/src/features/contactForms/components/forms/ContactForm.tsx
+++ b/src/features/contactForms/components/forms/ContactForm.tsx
@@ -1,10 +1,11 @@
 'use client'
 
+import { ContactFormEntry } from '@/api/gql/graphql'
+import { EmailTemplates } from '@/features/emails/types/EmailTemplates'
+import { sendEmail, SendEmailProps } from '@/features/emails/utils/sendEmail'
 import React from 'react'
 import * as yup from 'yup'
 import { FormConfig } from '../../types/FormConfig'
-
-import { ContactFormEntry } from '@/api/gql/graphql'
 import { createContactEntry } from '../../utils/createContactEntry'
 import { RenderForm } from '../RenderForm'
 
@@ -31,8 +32,28 @@ const formConfig: FormConfig<ContactFormValues> = {
       email: values?.email,
       message: values?.message,
     }
-    const { success } = await createContactEntry(entryData)
-    return success
+
+    const emailProps: SendEmailProps = {
+      to: ['liquidmilesrace@gmail.com'],
+      // @TODO: replace or remove me from CC once the LM Resend account is active
+      cc: ['ericnowels@gmail.com'],
+      from: 'contact',
+      replyTo: 'liquidmilesrace@gmail.com',
+      subject: `Contact Message from ${values.name}`,
+      messageData: {
+        title: `Contact Message from ${values.name}`,
+        recipientName: values.name,
+        message: values?.message,
+      },
+      template: EmailTemplates.Message,
+    }
+
+    const [contentfulResponse, emailResponse] = await Promise.all([
+      await createContactEntry(entryData),
+      await sendEmail(emailProps),
+    ])
+
+    return contentfulResponse.success || emailResponse.success
   },
   formControlsProps: {
     submitLabel: 'Send It',

--- a/src/features/contactForms/components/forms/ContactForm.tsx
+++ b/src/features/contactForms/components/forms/ContactForm.tsx
@@ -38,7 +38,8 @@ const formConfig: FormConfig<ContactFormValues> = {
       // @TODO: replace or remove me from CC once the LM Resend account is active
       cc: ['ericnowels@gmail.com'],
       from: 'contact',
-      replyTo: 'liquidmilesrace@gmail.com',
+      // replyTo: 'liquidmilesrace@gmail.com',
+      replyTo: values.email,
       subject: `Contact Message from ${values.name}`,
       messageData: {
         title: `Contact Message from ${values.name}`,

--- a/src/features/contactForms/components/forms/ContactForm.tsx
+++ b/src/features/contactForms/components/forms/ContactForm.tsx
@@ -38,7 +38,6 @@ const formConfig: FormConfig<ContactFormValues> = {
       // @TODO: replace or remove me from CC once the LM Resend account is active
       cc: ['ericnowels@gmail.com'],
       from: 'contact',
-      // replyTo: 'liquidmilesrace@gmail.com',
       replyTo: values.email,
       subject: `Contact Message from ${values.name}`,
       messageData: {

--- a/src/features/emails/readme.md
+++ b/src/features/emails/readme.md
@@ -32,6 +32,7 @@ const emailResponse = await sendEmail({
   bcc: ['someone-else@a-domain.com'],
   from: 'hello',
   replyTo: 'liquidmilesrace@gmail.com',
+  subject: 'Hellow there!',
   messageData: {
     title: 'The headline',
     recipientName: 'FirstName',

--- a/src/features/emails/readme.md
+++ b/src/features/emails/readme.md
@@ -32,7 +32,7 @@ const emailResponse = await sendEmail({
   bcc: ['someone-else@a-domain.com'],
   from: 'hello',
   replyTo: 'liquidmilesrace@gmail.com',
-  subject: 'Hellow there!',
+  subject: 'Hello there!',
   messageData: {
     title: 'The headline',
     recipientName: 'FirstName',

--- a/src/features/emails/utils/sendEmail.ts
+++ b/src/features/emails/utils/sendEmail.ts
@@ -40,10 +40,11 @@ const sendEmail = async (
     data: null,
   }
   try {
-    const { to, subject, messageData, template } = sendProps
+    const { to, cc, subject, messageData, template } = sendProps
     const from = `${sendProps?.from || 'noreply'}@${verifiedDomain}`
     const { data, error } = await resend.emails.send({
       from,
+      cc,
       replyTo: [sendProps.replyTo || from],
       to,
       subject,


### PR DESCRIPTION
Send email to LM gmail when user submits contact form.

**Preview**: **[Contact Page](https://liquid-miles-web-git-transactiona-7b9398-austincorwins-projects.vercel.app/contact)**

___

In addition to creating a Contentful record on form submission an email will be sent to liquidmilesrace@gmail.com with the reply-to set as the user's email so you can pick up the conversation by just hitting reply. 
